### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and start it up:
 
 ```bash
 $ cd registry
-$ docker-compose up
+$ docker-compose up -d
 ```
 It's done.
 


### PR DESCRIPTION
added "-d" to run in detached mode: Run containers in the background, print new container names. Incompatible with --abort-on-container-exit.